### PR TITLE
붕대감기[김도림]

### DIFF
--- a/Week4/kimdorim/src/Solution.java
+++ b/Week4/kimdorim/src/Solution.java
@@ -1,0 +1,40 @@
+public class Solution {
+    public int solution(int[] bandage, int health, int[][] attacks) {
+        int playerHealth = health;
+        int time = 0;
+        int lastAttackTime = attacks[attacks.length - 1][0];
+
+        for (int i = 0; i <= lastAttackTime; i++) {
+            boolean attacked = false; // flag
+
+            for (int[] attack : attacks) {
+                if (attack[0] == i) { // 현재 시간이 공격 시간과 일치할 때
+                    playerHealth -= attack[1];
+                    attacked = true;
+                    time = 0;
+                    break;
+                }
+            }
+
+            if (!attacked) { // 공격이 없을 때만 회복 로직 실행
+                playerHealth += bandage[1];
+                time += 1;
+
+                if (time == bandage[0]) {
+                    playerHealth += bandage[2];
+                    time = 0;
+                }
+
+                if (playerHealth >= health) {
+                    playerHealth = health;
+                }
+            }
+
+            if (playerHealth <= 0) {
+                return -1;
+            }
+        }
+
+        return playerHealth;
+    }
+}


### PR DESCRIPTION
### 📌 문제 설명

- 문제 입력 : bandage[시전 시간, 초당 회복량, 추가 회복량] 배열 / health(플레이어의 최대 체력) / attacks[ [몬스터 1의 공격 시간, 피해량 ], [몬스터 2의 공격 시간, 피해량 ], .... , [몬스터 n의 공격 시간, 피해량 ] ] 배열

- 문제 출력 : 모든 몬스터의 공격이 끝난 후의 플레이어의 체력 리턴 / 만일 몬스터의 공격을 받아 플레이어가 죽는다면 -1 리턴
  
- 주요 조건들 : 
1 ≤ 시전 시간 ≤ 50
1 ≤ 초당 회복량  ≤ 100
1 ≤ 추가 회복량  ≤ 100

1 ≤ health ≤ 1,000

1 ≤ 공격 시간 ≤ 1,000
1 ≤ 피해량 ≤ 100


### 📌 문제 접근법

 health를 받을 playerHealth를 선언, 회복 연속 성공 시간을 저장할 time 변수 선언, attacks 2차원 배열에서 마지막 배열의 시간을 종료시간으로 하기 위하여 lastAttackTime으로 선언하였습니다. 
 현재 시간과 공격 시간이 일치할 때 playerHealth를 몬스터의 피해량만큼 감하고 플래그 변수 attacked를 바꾸어 힐을 안 받고 다음으로 넘어가도록 하였습니다. attacked가 false일 때 playHealth를 초당 회복량 만큼 가산하고, time 또한 1 더하여 회복 연속 시간이 시전 시간과 같아진다면 추가 회복을 하고 다시 시간을 0으로 바꿀 수 있도록 하고 최대 체력을 넘지 않도록 하는 조건문 또한 추가하였습니다. 이 과정 중 플레이어의 체력이 0이하가 되면 죽었다는 것을 리턴하기 위하여 -1을 리턴하도록 하였습니다.  

### 📌 풀이 결과

![image](https://github.com/user-attachments/assets/ab305c26-436b-436d-a3ba-3edeb896f15e)
